### PR TITLE
feat: HTTP mode for Cloud Run (health checks + CORS)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,15 @@ import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
 import {AirtableService} from './airtableService.js';
 import {AirtableMCPServer} from './mcpServer.js';
 import {logger} from './logger.js';
+import http from 'http';
 
 const main = async () => {
-	const apiKey = process.argv.slice(2)[0];
-	if (apiKey) {
+	// Prefer env vars first so Cloud Run secrets work, fall back to CLI arg for local/dev
+	const envApiKey = process.env.AIRTABLE_API_KEY ?? process.env.AIRTABLE_PAT;
+	const cliApiKey = process.argv.slice(2)[0];
+	const apiKey = envApiKey ?? cliApiKey;
+
+	if (cliApiKey) {
 		// Deprecation warning
 		logger.warn('Passing in an API key as a command-line argument is deprecated and may be removed in a future version. Instead, set the `AIRTABLE_API_KEY` environment variable. See https://github.com/domdomegg/airtable-mcp-server/blob/master/README.md#usage for an example with Claude Desktop.');
 	}
@@ -41,8 +46,57 @@ const main = async () => {
 	}
 
 	const server = new AirtableMCPServer(airtableService);
-	const transport = new StdioServerTransport();
-	await server.connect(transport);
+	const portEnv = process.env.PORT;
+	const enableCors = process.env.ENABLE_CORS === 'true';
+	const allowedOrigins = process.env.ALLOWED_ORIGINS ?? '*';
+
+	// Decide transport(s)
+	if (portEnv) {
+		// Cloud-Run / HTTP mode
+		const port = Number(portEnv);
+		const httpServer = http.createServer(async (req, res) => {
+			// CORS handling
+			if (enableCors) {
+				res.setHeader('Access-Control-Allow-Origin', allowedOrigins);
+				res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+				res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+			}
+
+			// Pre-flight
+			if (req.method === 'OPTIONS') {
+				res.writeHead(204);
+				return res.end();
+			}
+
+			// Basic health endpoints
+			if (req.method === 'GET' && (req.url === '/' || req.url === '/healthz')) {
+				res.writeHead(200, {'Content-Type': 'text/plain'});
+				return res.end('ok');
+			}
+
+			// MCP HTTP transport not yet implemented
+			res.writeHead(404, {'Content-Type': 'text/plain'});
+			return res.end('Not Found');
+		});
+
+		httpServer.listen(port, () => {
+			logger.info({port}, 'HTTP server started');
+		});
+
+		// Only start stdio transport if explicitly requested
+		if (process.env.STDIO_MODE === '1') {
+			logger.info('Starting stdio transport (STDIO_MODE=1)');
+			const transport = new StdioServerTransport();
+			await server.connect(transport);
+		} else {
+			logger.info('STDIO transport disabled (set STDIO_MODE=1 to enable)');
+		}
+	} else {
+		// Local / CLI usage with stdio
+		const transport = new StdioServerTransport();
+		logger.info('Starting stdio transport (no PORT set)');
+		await server.connect(transport);
+	}
 };
 
 main().catch((error: unknown) => {


### PR DESCRIPTION
This is a Droid-assisted PR.

Adds HTTP mode for Cloud Run deployments:
- Detects PORT to run an HTTP server
- Health endpoints: GET / and GET /healthz -> 200 "ok"
- CORS support when ENABLE_CORS=true (ALLOWED_ORIGINS defaults to "*")
- Keeps stdio transport for local or when STDIO_MODE=1 in Cloud Run
- Prefers env AIRTABLE_API_KEY or AIRTABLE_PAT over CLI arg

Notes
- MCP HTTP transport endpoints are not implemented in this change; this is to satisfy Cloud Run health checks and enable basic HTTP/CORS scaffolding. Stdio remains for local MCP clients.

Follow-up
- Configure Cloud Run envs: ENABLE_CORS=true, ALLOWED_ORIGINS as desired
- Map Secret Manager secret AIRTABLE_PAT to runtime env AIRTABLE_API_KEY

Thanks!

---
**Factory Session:** https://app.factory.ai/sessions/iqH2P5ayWsacr1nyOrAL (created by lifeofgurpreet)